### PR TITLE
Pin rustc version to nightly-2023-06-28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 override RUSTFLAGS += -Ctarget-cpu=native
 
 # this indirection is so commands with env are easily copied on the terminal
-CARGO ?= RUSTFLAGS="$(RUSTFLAGS)" cargo +nightly
+CARGO ?= RUSTFLAGS="$(RUSTFLAGS)" cargo +nightly-2023-06-28
 
 .PHONY: all build
 all build:


### PR DESCRIPTION
This avoids a weird "unknown feature `proc_macro_span_shrink`" error that occurs somewhere in the proc-macro2 crate.

I think this is the relevant issue:
https://github.com/dtolnay/proc-macro2/issues/356

Pinning the exact compiler version seems like the only way to avoid this sort of dependency churn when using nightly features. This can be manually updated in the future, assuming related compilation errors are fixed.